### PR TITLE
Fix broken PhysicsConnector

### DIFF
--- a/src/org/andengine/extension/physics/box2d/PhysicsConnector.java
+++ b/src/org/andengine/extension/physics/box2d/PhysicsConnector.java
@@ -59,8 +59,8 @@ public class PhysicsConnector implements IUpdateHandler, PhysicsConstants {
 		this.mUpdateRotation = pUpdateRotation;
 		this.mPixelToMeterRatio = pPixelToMeterRatio;
 
-		this.mShapeHalfBaseWidth = pAreaShape.getBaseWidth() * 0.5f;
-		this.mShapeHalfBaseHeight = pAreaShape.getBaseHeight() * 0.5f;
+		this.mShapeHalfBaseWidth = pAreaShape.getWidthScaled() * 0.5f;
+		this.mShapeHalfBaseHeight = pAreaShape.getHeightScaled() * 0.5f;
 	}
 
 	// ===========================================================


### PR DESCRIPTION
AE commit 8a12c3c5cf8 (Removed mInitialX/Y and mBaseWidth/mBaseHeight)
removed some stuff that was referenced from box2d extension
